### PR TITLE
Fix the url encoding specific issues

### DIFF
--- a/google-play-scraper/src/main/java/com/arthurivanets/googleplayscraper/util/ScriptDataParser.kt
+++ b/google-play-scraper/src/main/java/com/arthurivanets/googleplayscraper/util/ScriptDataParser.kt
@@ -38,7 +38,7 @@ internal class DefaultScriptDataParser(private val gson: Gson) : ScriptDataParse
             )
         }
         private val PATTERN_KEY by lazy { Pattern.compile("'(ds:.*?)'") }
-        private val PATTERN_VALUE by lazy { Pattern.compile("data:([\\s\\S]*?), sideChannel: \\{}}\\);</") }
+        private val PATTERN_VALUE by lazy { Pattern.compile("data:([\\s\\S]*?), sideChannel: \\{\\}\\}\\);</") }
 
     }
 

--- a/google-play-scraper/src/main/java/com/arthurivanets/googleplayscraper/util/UriUtils.kt
+++ b/google-play-scraper/src/main/java/com/arthurivanets/googleplayscraper/util/UriUtils.kt
@@ -17,7 +17,6 @@
 package com.arthurivanets.googleplayscraper.util
 
 import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 @JvmInline
 value class UriComponent(val value: String)
@@ -28,7 +27,7 @@ fun UriComponent.encode(): String {
     }
 
     val encodedValue = try {
-        URLEncoder.encode(this.value, StandardCharsets.UTF_8)
+        URLEncoder.encode(this.value, "UTF-8")
     } catch (e: Exception) {
         throw e
     }


### PR DESCRIPTION
* Escape the previously unescaped regex pattern characters.
* Replace the [`URLEncoder.encode(String, Charset)`](https://developer.android.com/reference/java/net/URLEncoder#encode(java.lang.String,%20java.nio.charset.Charset)) with [`URLEncoder.encode(String, String)`](https://developer.android.com/reference/java/net/URLEncoder#encode(java.lang.String,%20java.lang.String)) to support the older versions of the Android SDK & Java JDK.